### PR TITLE
when calm, clear highlights when cursor moves in insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Hlslens will observe whether `nohlsearch` command is accepted.
         default = true
     },
     calm_down = {
-        description = [[When the cursor is out of the position range of the matched instance
-            and calm_down is true, clear all lens]],
+        description = [[If calm_down is true, clear all lens and highlighting When the cursor is
+            out of the position range of the matched instance or any texts are changed]],
         default = false,
     },
     nearest_only = {

--- a/lua/hlslens/main.lua
+++ b/lua/hlslens/main.lua
@@ -36,7 +36,7 @@ local function autocmd(initial)
     if not initial then
         cmd([[
             aug HlSearchLens
-                au CursorMoved * lua require('hlslens.main').refresh()
+                au CursorMoved,CursorMovedI * lua require('hlslens.main').refresh()
                 au WinEnter,TermLeave,VimResized * lua require('hlslens.main').refresh(true)
                 au TermEnter * lua require('hlslens.main').clearCurLens()
             aug END

--- a/lua/hlslens/main.lua
+++ b/lua/hlslens/main.lua
@@ -36,7 +36,7 @@ local function autocmd(initial)
     if not initial then
         cmd([[
             aug HlSearchLens
-                au CursorMoved * lua require('hlslens.main').refresh()
+                au CursorMoved,CursorMovedI * lua require('hlslens.main').refresh()
                 au WinEnter,TermLeave,VimResized * lua require('hlslens.main').refresh(true)
                 au TermEnter * lua require('hlslens.main').clearCurLens()
             aug END
@@ -190,7 +190,7 @@ function M.refresh(force)
     position.updateCache(bufnr, pattern, idx, rIdx)
 
     if calmDown then
-        if not position.inRange(startPos, endPos, curPos) then
+        if vim.fn.mode() == "i" or not position.inRange(startPos, endPos, curPos) then
             vim.schedule(function()
                 cmd('noh')
                 reset()

--- a/lua/hlslens/main.lua
+++ b/lua/hlslens/main.lua
@@ -36,7 +36,7 @@ local function autocmd(initial)
     if not initial then
         cmd([[
             aug HlSearchLens
-                au CursorMoved,CursorMovedI * lua require('hlslens.main').refresh()
+                au CursorMoved * lua require('hlslens.main').refresh()
                 au WinEnter,TermLeave,VimResized * lua require('hlslens.main').refresh(true)
                 au TermEnter * lua require('hlslens.main').clearCurLens()
             aug END
@@ -45,6 +45,7 @@ local function autocmd(initial)
             cmd([[
                 aug HlSearchLens
                     au TextChanged,TextChangedI * lua require('hlslens.main').nohAndReset()
+                    au CursorMovedI * lua require('hlslens.main').refresh()
                 aug END
             ]])
         end


### PR DESCRIPTION
I think that it's in the spirit of calm mode to clear highlights when the cursor moves in insert mode. Right now, it's a little strange when you `cw` the word you searched for but the highlight remains because you're still in its range (even though the word originally being highlighted is now gone).

Before:


https://user-images.githubusercontent.com/29129/189513126-6a0cb4f5-9ae8-4ef0-a0de-1b73ba45390a.mov



After:

https://user-images.githubusercontent.com/29129/189513111-b7a70893-bfbd-46b4-aaf5-e7b9533601e2.mov