### PR TITLE
fix(render): fix border is nil

### DIFF
--- a/lua/hlslens/render/floatwin.lua
+++ b/lua/hlslens/render/floatwin.lua
@@ -38,6 +38,10 @@ function FloatWin.getConfig(winid)
 end
 
 local function borderHasBottomLine(border)
+    if border == nil then
+        return false
+    end
+
     local s = border[6]
     if type(s) == 'string' then
         return s ~= ''


### PR DESCRIPTION
I've encountered lua error and neovim crash due to this bug that assuming window config always have border.

Below is the lua error:
```
Error executing vim.schedule lua callback: ...acker/start/nvim-hlslens/lua/hlslens/render/floatwin.lua:45: attempt to index local 'border' (a nil value)
stack traceback:
		...acker/start/nvim-hlslens/lua/hlslens/render/floatwin.lua:45: in function 'borderHasBottomLine'
		...acker/start/nvim-hlslens/lua/hlslens/render/floatwin.lua:105: in function 'updateFloatWin'
		...ck/packer/start/nvim-hlslens/lua/hlslens/render/init.lua:235: in function 'setVirt'
		...ck/packer/start/nvim-hlslens/lua/hlslens/render/init.lua:201: in function 'addLens'
		...ck/packer/start/nvim-hlslens/lua/hlslens/render/init.lua:333: in function 'doLens'
		...ck/packer/start/nvim-hlslens/lua/hlslens/render/init.lua:107: in function 'refreshCurrentBuf'
		...ck/packer/start/nvim-hlslens/lua/hlslens/render/init.lua:413: in function ''
		vim/_editor.lua: in function <vim/_editor.lua:0>
```

And the neovim core dump backtrace from this bug:
[bt.txt](https://github.com/kevinhwang91/nvim-hlslens/files/10030379/bt.txt)
