### PR TITLE
fix: hack the lua package.path for VimPlug

### DIFF
--- a/plugin/hlslens.vim
+++ b/plugin/hlslens.vim
@@ -10,4 +10,8 @@ endif
 
 let g:loaded_nvim_hlslens = 1
 
+let s:lua_loc = expand("<sfile>:h:r") . "./../lua"
+exe "lua package.path = package.path .. ';" . s:lua_loc . "'"
+
 lua vim.schedule(function() require('hlslens').setup(nil, true) end)
+


### PR DESCRIPTION
# Related issue
#52 

# Description
- Execute Lua command to add `hlslens.lua` location to package.path

# How to test
- Pull the branch
- Configure VimPlug with the pulled branch. E.g: `Plug '~/learn/repos/nvim-hlslens'`
- Restart NeoVim
- Execute lua command to check if the hlslens package is recognized `:lua require("hlslens").setup(nil, true)`

# References
- https://www.linode.com/docs/guides/write-a-neovim-plugin-with-lua/#vim-script-component