### PR TITLE
Remove Unnecessary Warning on Startup

### DIFF
--- a/lua/hlslens.lua
+++ b/lua/hlslens.lua
@@ -64,10 +64,6 @@ end
 function M.setup(opts, warnFlag)
     if not opts and warnFlag then
         vim.schedule(function()
-            if not initialized then
-                vim.notify([[nvim-hlslens need to invoke `require('hlslens').setup()` to boot!]],
-                           vim.log.levels.WARN)
-            end
             M.setup()
         end)
         return


### PR DESCRIPTION
The warning about invoking `require('hlslens').setup()` was redundant and caused unnecessary disruption on startup. This commit removes the notification logic to improve the user experience without affecting functionality.

Issue: https://github.com/kevinhwang91/nvim-hlslens/issues/73