### PR TITLE
fix: nvim_win_get_config can return border="none"

### DIFF
--- a/lua/hlslens/render/floatwin.lua
+++ b/lua/hlslens/render/floatwin.lua
@@ -40,7 +40,7 @@ function FloatWin.getConfig(winid)
 end
 
 local function borderHasBottomLine(border)
-    if border == nil then
+    if border == nil or border == 'none' then
         return false
     end
 


### PR DESCRIPTION
`nvim_win_get_config` can return `border="none"` for me.

## reproduction
`cd path/to/hlslen`
`nvim --clean --cmd "se rtp^=." +"lua require('hlslens').setup()" -u repro.lua`
```lua
vim.schedule(function()
    local buf = vim.api.nvim_create_buf(false, true)
    local s = 'abcdefghijklmnopqrstuvwxyz'
    vim.api.nvim_open_win(buf, true,
        {relative = 'cursor', height = 1, width = s:len(), row = 0, col = 0, style = 'minimal'})
    vim.api.nvim_buf_set_lines(buf, 0, -1, true, {s})
end)
```