### PR TITLE
fix(cmdline): nullify current cmd name

### DIFF
--- a/lua/hlslens/cmdline/parser.lua
+++ b/lua/hlslens/cmdline/parser.lua
@@ -98,6 +98,8 @@ function CmdLineParser:doParse()
                 elseif #self.range == 1 then
                     table.insert(self.range, self.range[1])
                 end
+            else
+                self.name, self.range = nil, nil
             end
             if #parsed.args == 0 or not self.name then
                 return false


### PR DESCRIPTION
BUG:
* `nvim --clean --cmd "se rtp^=." +"lua require('hlslens').setup()" lua/hlslens/cmdline/parser.lua`
* `:grep api`
* type `<esc>`

The cursor position is changed unexpectedly
