### PR TITLE
fix: redraw on clear highlights (on `/xx<c-w>`)

### DIFF
--- a/lua/hlslens/render/init.lua
+++ b/lua/hlslens/render/init.lua
@@ -354,6 +354,7 @@ function Render.clear(hl, bufnr, floated)
     if floated then
         floatwin:close()
     end
+    vim.schedule(vim.cmd.redraw)
 end
 
 function Render.clearAll()


### PR DESCRIPTION
* `nvim --clean --cmd "se rtp^=." +"lua require('hlslens').setup()" lua/hlslens/cmdline/init.lua `
* type `/hls<c-w>`

Expected: highlight of 'hls' should be cleared

Not sure why but add a redraw make it work.
