### PR TITLE
fix: only redraw on the first char that invalid the search

### DIFF
--- a/lua/hlslens/cmdline/init.lua
+++ b/lua/hlslens/cmdline/init.lua
@@ -32,6 +32,7 @@ local disposable = require('hlslens.lib.disposable')
 ---@field matchStart number[] (1, 0)-indexed position
 ---@field matchEnd number[] (1, 0)-indexed position
 ---@field keyCode number[]
+---@field last_range? number[]
 local CmdLine = {
     initialized = false,
     disposables = {}
@@ -234,10 +235,11 @@ function CmdLine:didChange()
     else
         self:resetState()
         render.clear(true, 0, true)
-        if self.parser.pattern == '' then
+        if self.last_range then
             vim.schedule(vim.cmd.redraw)
         end
     end
+    self.last_range = range
 end
 
 function CmdLine:detach(typ, abort)


### PR DESCRIPTION
In this case we also need to avoid redraw:
```sh
nvim --clean --cmd "se rtp^=." +"lua require('hlslens').setup()" lua/hlslens/cmdline/init.lua \
  +'lua vim.defer_fn(function() vim.api.nvim_input("/false" .. ("<c-g>"):rep(10) .. "<left>" ) end, 100)'
# then type `....`
```

to avoid flicker in https://github.com/kevinhwang91/nvim-hlslens/issues/91#issuecomment-3524941755 and and fix stale hl in #88