### PR TITLE
fix(cmdline): stale cursor before nvim_win_set_cursor

### DIFF
--- a/lua/hlslens/cmdline/init.lua
+++ b/lua/hlslens/cmdline/init.lua
@@ -73,7 +73,9 @@ end
 ---@param pattern string
 ---@return table|nil
 function CmdLine:searchRange(pattern)
-    api.nvim_win_set_cursor(0, self.searchStart)
+    if not pcall(api.nvim_win_set_cursor, 0, self.searchStart) then
+        return
+    end
     local flag = self.isSubstitute and 'c' or (self.type == '?' and 'b' or '')
     if self.range then
         flag = flag .. 'n'
@@ -112,7 +114,9 @@ end
 function CmdLine:incSearchPos(forward, pattern)
     local pos
     local cursor = self.matchEnd
-    api.nvim_win_set_cursor(0, cursor)
+    if not pcall(api.nvim_win_set_cursor, 0, cursor) then
+        return
+    end
     if forward then
         pos = utils.searchPosSafely(pattern, '')
         self.currentIdx = self.currentIdx == self.total and 1 or self.currentIdx + 1


### PR DESCRIPTION
Error often appear when I use this plugin with `max_messages` option.
https://github.com/sudo-tee/opencode.nvim/blob/2fb641678445047d9d814e05240d1b013c4ba642/README.md#L256

## Reproduce

e.g. buffer is changing in cmdline mode
```sh
cd /path/to/nvim-hlslen
nvim --clean -u repro.lua 
# then type `/foo`
```

```lua
vim.opt.runtimepath:prepend('.')

local lines = {}
for i = 1, 100 do lines[i] = 'line ' .. i .. ' foo' end
vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
vim.api.nvim_win_set_cursor(0, {80, 0})

require('hlslens').enable()

-- Register AFTER enable() so this autocmd fires after the plugin's own
-- CmdlineEnter handler (which is what caches searchStart = {80, 0}).
vim.api.nvim_create_autocmd('CmdlineEnter', {
    pattern = {'/', '?', ':'},
    callback = function()
        local shrunk = {}
        for i = 1, 10 do shrunk[i] = 'shrunk ' .. i .. ' foo' end
        vim.api.nvim_buf_set_lines(0, 0, -1, false, shrunk)
    end,
})
```
