### PR TITLE
fix(cmdline): swallow stale fold row errors in fold:undo

### DIFF
--- a/lua/hlslens/cmdline/fold.lua
+++ b/lua/hlslens/cmdline/fold.lua
@@ -30,7 +30,7 @@ end
 function IncSearchFold:undo()
     while #self.undoLnums > 0 do
         local l = table.remove(self.undoLnums)
-        cmd(l .. 'foldclose')
+        pcall(cmd, l .. 'foldclose')
     end
 end
 


### PR DESCRIPTION
This happened when search in opencode render buffer (https://github.com/sudo-tee/opencode.nvim).

```
CmdlineLeave Autocommands for "/": Vim(append):Lua callback: runtime/lua/vim/_core/editor.lua:490: CmdlineLeave Autocommands for "/"..script nvim_exec2() called at CmdlineLeave Autocommands for "/":0, line 1: Vim(foldclose):E490: No fold found
stack traceback:
	[C]: in function 'nvim_exec2'
	runtime/lua/vim/_core/editor.lua:490: in function 'cmd'
	nvim-hlslens/lua/hlslens/cmdline/fold.lua:33: in function 'undo'
	nvim-hlslens/lua/hlslens/cmdline/init.lua:256: in function 'detach'
	nvim-hlslens/lua/hlslens/cmdline/init.lua:344: in function 'listener'
	nvim-hlslens/lua/hlslens/lib/event.lua:52: in function 'emit'
	nvim-hlslens/lua/hlslens/main.lua:36: in function <nvim-hlslens/lua/hlslens/main.lua:33>
```

## reproduce

cd to hlslen, Prepare `./repro.lua`
```lua
vim.opt.runtimepath:prepend('.')
require('hlslens').enable()

local LOG = '/tmp/test_fold_stale3.log'
do local f = io.open(LOG, 'w') f:close() end
local function log(s)
    local f = io.open(LOG, 'a')
    f:write(s .. '\n')
    f:close()
end

vim.cmd('e /tmp/foo_fold.txt')
vim.cmd('set foldmethod=manual')
vim.cmd('1,2fold')
log('Created fold: 1-2, foldclosed(1)=' .. vim.fn.foldclosed(1))

vim.api.nvim_create_autocmd('CmdlineEnter', {
    callback = function()
        log('CmdlineEnter')
        -- 1000ms 后删除 fold, 让 fold:expand 先执行
        vim.defer_fn(function()
            log('Removing folds...')
            vim.cmd('normal! zE')
            log('Folds removed, foldclosed(1)=' .. vim.fn.foldclosed(1))
        end, 1000)
    end,
})

vim.api.nvim_create_autocmd({'CmdlineChanged', 'CmdlineLeave'}, {
    callback = function(ev)
        if ev.event == 'CmdlineChanged' then
            log('CmdlineChanged ' .. vim.fn.getcmdline())
        else
            log('CmdlineLeave abort=' .. tostring(vim.v.event.abort))
        end
    end,
})

-- Hook fold:expand / fold:undo
local fold = require('hlslens.cmdline.fold')
local orig_expand = fold.expand
fold.expand = function(self, lnum)
    local f = io.open('/tmp/test_fold_stale3.log', 'a')
    f:write('fold:expand(' .. lnum .. ')\n')
    f:close()
    return orig_expand(self, lnum)
end

local orig_undo = fold.undo
fold.undo = function(self)
    local f = io.open('/tmp/test_fold_stale3.log', 'a')
    f:write('fold:undo() undoLnums=' .. vim.inspect(self.undoLnums) .. '\n')
    return orig_undo(self)
end

io.stdout:write('READY\n')
io.stdout:flush()
```

`python repro.py` (may take a bit time, but can reproduce on my machine)

```py
#!/usr/bin/env python3
import os, pty, re, select, sys, time

def main():
    pid, fd = pty.fork()
    if pid == 0:
        os.environ['TERM'] = 'xterm-256color'
        os.environ['COLUMNS'] = '120'
        os.environ['LINES'] = '30'
        os.execvp('nvim', [
            'nvim', '-n', '-i', 'NONE', '--clean',
            '--cmd', 'set rtp^=/home/phan/lazy/nvim-hlslens',
            '-c', 'lua require("hlslens").enable()',
            '-c', 'luafile repro.lua',
            '/tmp/foo_test2.txt',
        ])

    out = b''
    deadline = time.time() + 8
    while time.time() < deadline:
        r, _, _ = select.select([fd], [], [], 0.2)
        if not r: continue
        try: c = os.read(fd, 4096)
        except OSError: break
        if not c: break
        out += c
        if b'foo aaa' in out: break

    # Send /foo
    time.sleep(1.0)
    os.write(fd, b'/foo')
    time.sleep(2.0)  # let autocmd + CmdlineChanged fire
    time.sleep(1.0)
    # ESC abort (triggers CmdlineLeave -> fold:undo)
    os.write(fd, b'\x1b')
    time.sleep(2.0)

    # Drain messages
    drained = b''
    deadline = time.time() + 1
    while time.time() < deadline:
        r, _, _ = select.select([fd], [], [], 0.2)
        if not r: break
        try: c = os.read(fd, 8192)
        except OSError: break
        if not c: break
        drained += c

    # Now show messages
    os.write(fd, b':messages\r')
    time.sleep(1.5)

    drained2 = b''
    deadline = time.time() + 1
    while time.time() < deadline:
        r, _, _ = select.select([fd], [], [], 0.2)
        if not r: break
        try: c = os.read(fd, 8192)
        except OSError: break
        if not c: break
        drained2 += c

    print('=== messages raw ===')
    sys.stdout.write(drained2.decode('utf-8', errors='replace'))

    try:
        os.write(fd, b'\x1b:qa!\r')
    except OSError: pass
    time.sleep(0.3)
    try:
        os.waitpid(pid, 0)
    except ChildProcessError: pass


if __name__ == '__main__':
    main()
```
